### PR TITLE
Ignore bc files generated by clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.ko
 *.obj
 *.elf
+*.bc
 
 # Linker output
 *.ilk


### PR DESCRIPTION
clang의 빌드 과정 중에 생성되는 임시 오브젝트 파일인 bc 확장자에 대해서 무시 처리 합니다.